### PR TITLE
Fix printer hostname in topology

### DIFF
--- a/modules/topology/home.nix
+++ b/modules/topology/home.nix
@@ -7,7 +7,7 @@
       interfaces.wlan = {
         network = "home";
         addresses = [
-          "espon.alq.ae"
+          "epson.alq.ae"
           "192.168.1.52"
         ];
       };


### PR DESCRIPTION
## Summary
- fix the hostname for the Epson printer entry

## Testing
- `nix flake show` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684154d4acb8832da6684d71e3b693df

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the hostname for the WLAN interface addresses of the "epson" node.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->