### PR TITLE
Fix mkcd for fish

### DIFF
--- a/modules/shell/default.nix
+++ b/modules/shell/default.nix
@@ -139,11 +139,11 @@ in
             '';
 
             mkcd = ''
-              if [[ -z $1 ]]; then
+              if test -z "$argv"; then
                 echo "Usage: mkcd <directory>"
                 return 1
-              fi
-              mkdir -p $1 && cd $1
+              end
+              mkdir -p "$argv"; and cd "$argv"
             '';
           };
           interactiveShellInit = ''


### PR DESCRIPTION
## Summary
- update mkcd function to be fish-friendly

## Testing
- `nix flake show` *(fails: interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_684157db81d0832da80c4ad1dbac3c37