### PR TITLE
Fix nom path in rebuild aliases

### DIFF
--- a/modules/shell/default.nix
+++ b/modules/shell/default.nix
@@ -101,8 +101,8 @@ in
         programs.fish = {
           enable = true;
           shellAliases = shellAliases // {
-            nrb = "sudo nixos-rebuild switch --flake github:humaidq/dotfiles#$(hostname) --refresh --log-format internal-json -v --show-trace &| nom --json";
-            nrbl = "sudo nixos-rebuild switch --flake .#$(hostname) --refresh --log-format internal-json -v --show-trace &| nom --json";
+            nrb = "sudo nixos-rebuild switch --flake github:humaidq/dotfiles#$(hostname) --refresh --log-format internal-json -v --show-trace &| ${pkgs.nix-output-monitor}/bin/nom --json";
+            nrbl = "sudo nixos-rebuild switch --flake .#$(hostname) --refresh --log-format internal-json -v --show-trace &| ${pkgs.nix-output-monitor}/bin/nom --json";
             nrblo = "sudo nixos-rebuild switch --flake .#$(hostname) --refresh --log-format internal-json -v --option substitute false --show-trace &| nom --json";
           };
           functions = {


### PR DESCRIPTION
## Summary
- point `nrb` and `nrbl` aliases directly to nix-output-monitor

## Testing
- `nix fmt`
- `nix flake check` *(fails: interrupted due to environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_68426b4ef858832d91fddd4ada698754