### PR TITLE
Update Nextcloud to version 31

### DIFF
--- a/modules/home-server/nextcloud.nix
+++ b/modules/home-server/nextcloud.nix
@@ -16,7 +16,7 @@ in
     };
     services.nextcloud = {
       enable = true;
-      package = pkgs.nextcloud30;
+      package = pkgs.nextcloud31;
       hostName = "cloud.alq.ae";
       config.dbtype = "sqlite";
       config.adminpassFile = config.sops.secrets."nextcloud/adminpass".path;


### PR DESCRIPTION
## Summary
- bump Nextcloud service to `nextcloud31`

## Testing
- `nix fmt`
- `nix flake check --no-build` *(fails: path '/nix/store/q29ibsknirhsia8bgzf6p9xv6a0r4shb-dev' is not valid)*

------
https://chatgpt.com/codex/tasks/task_e_6842807b035c832db4c3d488e6bf1a5c