### PR TITLE
router: fix download QoS prioritisation

### DIFF
--- a/modules/router/default.nix
+++ b/modules/router/default.nix
@@ -51,11 +51,6 @@ in
       type = lib.types.path;
       description = "Path to file containing the ISP provided credentials for PPPoE authentication.";
     };
-    ifb = lib.mkOption {
-      type = lib.types.str;
-      default = "ifb0";
-      description = "Virtual interface for traffic shaping.";
-    };
     dhcp = {
       rangeStart = lib.mkOption {
         type = lib.types.str;
@@ -102,7 +97,7 @@ in
       download = lib.mkOption {
         type = lib.types.str;
         default = "900Mbit";
-        description = "Upload speed from WAN.";
+        description = "Download speed from WAN.";
       };
     };
     qos = {
@@ -141,7 +136,6 @@ in
 
   config = lib.mkIf cfg.enable {
     boot.kernelModules = [
-      "ifb"
       "sch_cake"
     ];
     boot.kernel.sysctl = {

--- a/modules/router/qos.nix
+++ b/modules/router/qos.nix
@@ -13,7 +13,7 @@ in
   config = lib.mkIf cfg.enable {
     systemd.services = lib.mkIf config.services.pppd.enable {
       cake-sqm = {
-        description = "Apply CAKE SQM to ${cfg.ppp}";
+        description = "Apply CAKE SQM to ${cfg.ppp} (upload) and ${cfg.lan0} (download)";
         after = [ pppdService ];
         bindsTo = [ pppdService ];
         partOf = [ pppdService ];
@@ -21,7 +21,6 @@ in
 
         path = with pkgs; [
           iproute2
-          kmod
         ];
 
         serviceConfig = {
@@ -31,42 +30,34 @@ in
             set -euo pipefail
 
             tc qdisc del dev ${cfg.ppp} root 2>/dev/null || true
-            tc qdisc del dev ${cfg.ppp} ingress 2>/dev/null || true
-            tc qdisc del dev ${cfg.ifb} root 2>/dev/null || true
-            ip link set dev ${cfg.ifb} down 2>/dev/null || true
+            tc qdisc del dev ${cfg.lan0} root 2>/dev/null || true
           '';
         };
 
+        # The download shaper deliberately lives on the LAN interface egress
+        # rather than on a WAN-ingress -> ifb redirect. A WAN ingress qdisc runs
+        # before netfilter's forward hook, so the DSCP marks applied by the
+        # nftables qos-mark chain would never be visible to a download shaper
+        # fed from there. Shaping LAN egress runs after the forward hook, so
+        # CAKE's diffserv4 classifier sees the marks and prioritisation works in
+        # both directions.
         script = ''
           set -euo pipefail
 
-          modprobe ifb || true
-
-          if ! ip link show dev ${cfg.ifb} >/dev/null 2>&1; then
-            ip link add ${cfg.ifb} type ifb
-          fi
-
-          ip link set dev ${cfg.ifb} up
-
-          tc qdisc del dev ${cfg.ppp} root 2>/dev/null || true
-          tc qdisc del dev ${cfg.ppp} ingress 2>/dev/null || true
-          tc qdisc del dev ${cfg.ifb} root 2>/dev/null || true
-
+          # Upload: egress of the PPP uplink. "nat" recovers the real LAN source
+          # behind the masquerade so dual-srchost fairness is per-LAN-host.
           tc qdisc replace dev ${cfg.ppp} root cake \
             bandwidth ${cfg.bandwidth.upload} \
             diffserv4 \
             nat \
             dual-srchost
 
-          tc qdisc add dev ${cfg.ppp} handle ffff: ingress
-
-          tc filter add dev ${cfg.ppp} parent ffff: protocol all matchall \
-            action mirred egress redirect dev ${cfg.ifb}
-
-          tc qdisc replace dev ${cfg.ifb} root cake \
+          # Download: egress towards the LAN. At this point reverse-NAT has
+          # already restored the real LAN destination, so "nat" is unnecessary;
+          # dual-dsthost gives per-LAN-host fairness on inbound traffic.
+          tc qdisc replace dev ${cfg.lan0} root cake \
             bandwidth ${cfg.bandwidth.download} \
             diffserv4 \
-            nat \
             dual-dsthost
         '';
       };


### PR DESCRIPTION
The download CAKE shaper was fed by a ppp0 ingress -> ifb redirect, which
runs before netfilter's forward hook. The DSCP marks applied by the
qos-mark chain were therefore never visible to the download shaper, so
diffserv4 prioritisation only worked for upload.

Shape the download direction on the LAN interface egress instead, which
runs after the forward hook. This removes the ifb apparatus entirely and
lets the existing DSCP marking drive prioritisation in both directions.