### PR TITLE
router: advertise IPv6 DNS to the LAN via RA

### DIFF
--- a/modules/router/default.nix
+++ b/modules/router/default.nix
@@ -184,6 +184,18 @@ in
             SubnetId = 0;
             Announce = true;
           };
+          # Advertise the router as the IPv6 recursive DNS server (RDNSS) and
+          # the local domain as a search list (DNSSL) so IPv6-only clients have
+          # a resolver. The link-local address is used rather than the global
+          # one because the delegated prefix changes (e.g. on the daily PPP
+          # redial); the link-local address is stable, and dnsmasq already
+          # listens on it via interface=lan0.
+          ipv6SendRAConfig = {
+            EmitDNS = true;
+            DNS = [ "_link_local" ];
+            EmitDomains = true;
+            Domains = [ cfg.localDomain ];
+          };
         };
         "30-ppp0" = {
           matchConfig.Name = cfg.ppp;


### PR DESCRIPTION
## Summary

RA was enabled on the LAN but carried no RDNSS/DNSSL, so IPv6-only clients had no resolver and silently depended on IPv4 DNS. The `[IPv6SendRA]` section now advertises the router's **link-local** address as the recursive DNS server (RDNSS) and the local domain as a search list (DNSSL).

Link-local is used rather than the global address because the delegated prefix (and thus the GUA) changes on PPP redial — notably the daily 05:00 redial — while the link-local address is stable, and dnsmasq already listens on it via `interface=lan0`. systemd-networkd's `_link_local` token substitutes the interface's actual link-local address into the RA, and RDNSS with a link-local address is well supported by modern clients (systemd-resolved, Android, Windows, macOS/iOS).

## Files

- `modules/router/default.nix` — add `ipv6SendRAConfig` (RDNSS + DNSSL) to the `20-lan0` network

## Testing

`nix flake check` was **not** run — the authoring environment has no Nix. Please let CI / a Nix host evaluate before merging.

Post-deploy checks:

```
rdisc6 enp2s0                  # RA should carry RDNSS + DNSSL
# on a client:
resolvectl status              # router fe80::… listed as IPv6 DNS server
dig AAAA example.com @<router-link-local>%<iface>
```

One thing to watch on first deploy: confirm dnsmasq answers DNS on the link-local address (default `interface=` behaviour should cover it; if queries time out, adding `bind-dynamic` to the dnsmasq settings forces per-address binding).

https://claude.ai/code/session_017MZiCbzYazZ7B7yFbfb6Sd