### PR TITLE
router/ip-blocklist: degrade gracefully when a feed fails

### DIFF
--- a/modules/router/ip-blocklist.nix
+++ b/modules/router/ip-blocklist.nix
@@ -114,13 +114,28 @@ in
         trap 'rm -rf "$downloads"; rm -f "$tmp" "$tmpnft"' EXIT
 
         : > "$tmp"
+        ok=0
+        failed=0
         ${lib.concatMapStringsSep "\n" (url: ''
-          curl --fail --silent --show-error --location \
-            "${url}" \
-            -o "$downloads/${builtins.hashString "sha256" url}.txt"
-          cat "$downloads/${builtins.hashString "sha256" url}.txt" >> "$tmp"
-          printf '\n' >> "$tmp"
+          if curl --fail --silent --show-error --location \
+               "${url}" \
+               -o "$downloads/${builtins.hashString "sha256" url}.txt"; then
+            cat "$downloads/${builtins.hashString "sha256" url}.txt" >> "$tmp"
+            printf '\n' >> "$tmp"
+            ok=$((ok + 1))
+          else
+            failed=$((failed + 1))
+            echo "nft-blocklists-update: feed download failed, skipping: ${url}" >&2
+          fi
         '') ipBlocklistUrls}
+
+        if [ "$ok" -eq 0 ]; then
+          echo "nft-blocklists-update: all $failed feed(s) failed to download, keeping cached blocklist" >&2
+          exit 1
+        fi
+        if [ "$failed" -gt 0 ]; then
+          echo "nft-blocklists-update: continuing with $ok of $((ok + failed)) feed(s)" >&2
+        fi
 
         python3 - "$tmp" "$tmpnft" <<'PY'
         import ipaddress


### PR DESCRIPTION
## Problem

In `nft-blocklists-update`, each `curl --fail` ran bare under `set -euo pipefail`, so a single feed failing aborted the entire refresh — even when the other feeds downloaded fine.

## Fix

Wrap each download in an `if`/`else`:

- A failed feed is logged and skipped, and the loop continues with whatever downloaded. (`if` conditions don't trip `set -e`.)
- `ok`/`failed` counters track outcomes; a partial run logs `continuing with N of M feed(s)`.
- Only bail (keeping the cached blocklist applied by `nft-blocklists-restore`) when **every** feed fails.

The existing small-list sanity guard (`refusing suspiciously small blocklist`, < 1000 entries) is untouched and still rejects partial sets that are too small to be credible.

## Testing

No Nix toolchain is available in the session container, so `nix flake check` / `nix fmt` were **not** run — please verify locally before deploying to the router.

https://claude.ai/code/session_01CjZ6QNmJqt8tnyjdrxReRn

---
_Generated by [Claude Code](https://claude.ai/code/session_01CjZ6QNmJqt8tnyjdrxReRn)_