### PR TITLE
sway: drop legacy WLR cursor and atomic workarounds

### DIFF
--- a/hosts/anoa/default.nix
+++ b/hosts/anoa/default.nix
@@ -210,6 +210,11 @@
     asdbctl # apple studio display
     intel-gpu-tools
   ];
+
+  # Intel VAAPI hardware video decode (iHD/intel-media-driver) so browsers
+  # and mpv offload video off the CPU, saving battery and heat.
+  hardware.graphics.extraPackages = with pkgs; [ intel-media-driver ];
+  environment.sessionVariables.LIBVA_DRIVER_NAME = "iHD";
   boot.loader.systemd-boot.enable = lib.mkForce false;
   boot.loader.efi.canTouchEfiVariables = false;
   services.hardware.bolt.enable = true;

--- a/modules/desktop/sway/default.nix
+++ b/modules/desktop/sway/default.nix
@@ -112,10 +112,6 @@ in
 
         networkmanagerapplet
       ];
-      extraSessionCommands = ''
-        export WLR_NO_HARDWARE_CURSORS=1
-        export WLR_DRM_NO_ATOMIC=1
-      '';
     };
 
     home-manager.users."${vars.user}" = {


### PR DESCRIPTION
WLR_NO_HARDWARE_CURSORS and WLR_DRM_NO_ATOMIC were carried over from
older hardware. On modern Intel they only hurt: software cursors add
CPU/lag (notably on the 5K Studio Display), and disabling atomic
modesetting degrades multi-output/modeset reliability and blocks VRR.