### PR TITLE
desktop: unlock gnome-keyring via greetd PAM

### DIFF
--- a/modules/desktop/wayland-services.nix
+++ b/modules/desktop/wayland-services.nix
@@ -97,6 +97,10 @@ in
       pkgs.gcr
     ];
 
+    # Unlock the gnome-keyring with the login password when logging in through
+    # greetd, so rbw's pinentry-gnome3 / gcr don't prompt for it separately.
+    security.pam.services.greetd.enableGnomeKeyring = true;
+
     home-manager.users."${vars.user}" = {
       # home manager services
       services = {


### PR DESCRIPTION
greetd's PAM stack didn't include pam_gnome_keyring, so the login
password never unlocked the keyring and rbw's pinentry-gnome3 / gcr
prompted separately. Enable enableGnomeKeyring on the greetd PAM
service so the keyring is unlocked at login.