### PR TITLE
desktop: inhibit idle on fullscreen, drop duplicate dunst package

### DIFF
--- a/modules/desktop/sway/default.nix
+++ b/modules/desktop/sway/default.nix
@@ -185,6 +185,20 @@ in
             ];
           };
 
+          # Stop swayidle from dimming/locking while a window is fullscreen
+          # (e.g. videos). Covers both wayland-native (app_id) and xwayland
+          # (class) clients.
+          window.commands = [
+            {
+              criteria.app_id = ".*";
+              command = "inhibit_idle fullscreen";
+            }
+            {
+              criteria.class = ".*";
+              command = "inhibit_idle fullscreen";
+            }
+          ];
+
           terminal = "foot";
           # https://github.com/nix-community/home-manager/blob/master/modules/services/window-managers/i3-sway/sway.nix
           keybindings = lib.mkOptionDefault {

--- a/modules/desktop/wayland-services.nix
+++ b/modules/desktop/wayland-services.nix
@@ -63,7 +63,6 @@ in
       swayidle
       chayang # gradual screen dimming
       libnotify
-      dunst # notification daemon
       caffeineToggle
       suspendIfAllowed
       cliphist # clipboard history


### PR DESCRIPTION
Add for_window inhibit_idle fullscreen rules (app_id + class) so
fullscreen videos no longer dim or lock the screen via swayidle.

Remove the redundant dunst package from systemPackages; the
home-manager services.dunst module already installs and runs it.