### PR TITLE
laptop: enable TLP power management with ThinkPad charge limits

### DIFF
--- a/modules/laptop/default.nix
+++ b/modules/laptop/default.nix
@@ -33,6 +33,29 @@
       pkgs.simple-scan
     ];
 
+    # Power management. thermald is already pulled in by the nixos-hardware
+    # Intel/ThinkPad profiles, so we only add the power daemon and battery
+    # charge limits here. TLP and power-profiles-daemon are mutually
+    # exclusive; we use TLP because it also exposes ThinkPad charge thresholds.
+    services.power-profiles-daemon.enable = false;
+    services.tlp = {
+      enable = true;
+      settings = {
+        # Performance on AC, save power on battery.
+        CPU_SCALING_GOVERNOR_ON_AC = "performance";
+        CPU_SCALING_GOVERNOR_ON_BAT = "powersave";
+        CPU_ENERGY_PERF_POLICY_ON_AC = "performance";
+        CPU_ENERGY_PERF_POLICY_ON_BAT = "power";
+        PLATFORM_PROFILE_ON_AC = "performance";
+        PLATFORM_PROFILE_ON_BAT = "low-power";
+
+        # Cap battery charge for longevity (ThinkPads, via thinkpad_acpi).
+        # Ignored on hardware that lacks charge-threshold support.
+        START_CHARGE_THRESH_BAT0 = 75;
+        STOP_CHARGE_THRESH_BAT0 = 80;
+      };
+    };
+
     services.printing = {
       enable = true;
       drivers = with pkgs; [


### PR DESCRIPTION
Enable TLP to switch CPU/platform profiles between AC and battery, and
cap battery charge at 75/80% on ThinkPads for longevity. thermald is
already provided by the nixos-hardware Intel/ThinkPad profiles, so it is
not duplicated. power-profiles-daemon is kept disabled to avoid the
mutual-exclusion conflict with TLP.