### PR TITLE
desktop: remove dead and disabled config

### DIFF
--- a/modules/desktop/apps.nix
+++ b/modules/desktop/apps.nix
@@ -66,7 +66,6 @@ in
         alsa-utils
       ];
       services.fwupd.enable = true;
-      #services.power-profiles-daemon.enable = true;
 
       # for localsend
       networking.firewall.allowedTCPPorts = [ 53317 ];

--- a/modules/desktop/default.nix
+++ b/modules/desktop/default.nix
@@ -115,28 +115,6 @@ in
             "file:///home/${vars.user}/inbox/web"
           ];
         };
-
-        programs.ghostty = {
-          enable = false;
-          settings = {
-            theme = "Dracula";
-            font-family = if cfg.berkeley.enable then "Berkeley Mono" else "Fira Code";
-            font-size = "12";
-
-            # For ssh
-            shell-integration-features = "ssh-terminfo,ssh-env";
-
-            # Don't inherit working dir
-            working-directory = "home";
-            window-inherit-working-directory = false;
-            tab-inherit-working-directory = false;
-            split-inherit-working-directory = false;
-            confirm-close-surface = false;
-
-            # No "are you sure" dialog
-            window-save-state = "never";
-          };
-        };
       };
     })
   ];

--- a/modules/desktop/sway/default.nix
+++ b/modules/desktop/sway/default.nix
@@ -136,9 +136,6 @@ in
         SSH_ASKPASS_REQUIRE = "prefer";
       };
 
-      #xfconf.settings = {
-      #};
-
       wayland.windowManager.sway = {
         enable = true;
         config = {

--- a/modules/desktop/wayland-services.nix
+++ b/modules/desktop/wayland-services.nix
@@ -94,16 +94,6 @@ in
     ];
 
     systemd.user.services = {
-      ianny = {
-        enable = false;
-        description = "ianny daemon";
-        serviceConfig = {
-          Type = "simple";
-          ExecStart = "${pkgs.ianny}/bin/ianny";
-        };
-        partOf = [ "graphical-session.target" ];
-        wantedBy = [ "graphical-session.target" ];
-      };
       cliphist = {
         enable = true;
         description = "Clipboard history daemon";


### PR DESCRIPTION
- Drop the disabled ianny user service (enable = false)
- Remove the commented-out xfconf.settings block in sway
- Remove the disabled programs.ghostty block (ghostty is installed via apps.nix)
- Drop the noisy commented power-profiles-daemon line (TLP is used)