### PR TITLE
Remove dangling dns.alq.ae vhost and its references

### DIFF
--- a/hosts/oreamnos/default.nix
+++ b/hosts/oreamnos/default.nix
@@ -332,12 +332,6 @@
         port = "123";
         proto = "udp";
       }
-      # DNS over https
-      {
-        host = "any";
-        port = "3333";
-        proto = "any";
-      }
       # Forgejo SSH
       {
         host = "any";

--- a/modules/home-server/homepage/index.html
+++ b/modules/home-server/homepage/index.html
@@ -165,12 +165,6 @@
           <div class="desc">Nix Binary Cache</div>
         </a>
       </li>
-      <li>
-        <a href="https://dns.alq.ae/">
-          <div class="service-name">Local DNS</div>
-          <div class="desc">DNS+DoH with ad-blocking (blocky)</div>
-        </a>
-      </li>
     </ul>
   </section>
 

--- a/modules/home-server/web-server.nix
+++ b/modules/home-server/web-server.nix
@@ -82,7 +82,6 @@ in
         #(mkRP "" "8082")
         (mkRP "cache" "5000")
         (mkRP "hydra" "3300")
-        (mkRP "dns" "3333")
         (mkRP "vault" "8222")
         (mkRP "grafana" "3000")
         (mkRP "pdf" "8084")

--- a/modules/personal/o11y/server.nix
+++ b/modules/personal/o11y/server.nix
@@ -38,16 +38,6 @@ in
       port = 9001;
       extraFlags = [ "--web.enable-remote-write-receiver" ];
       retentionTime = "30d";
-      scrapeConfigs = [
-        {
-          job_name = "blocky";
-          static_configs = [
-            {
-              targets = [ "localhost:3333" ];
-            }
-          ];
-        }
-      ];
     };
     services.loki = {
       enable = true;


### PR DESCRIPTION
The dns.alq.ae vhost proxied to 127.0.0.1:3333, but nothing listens on
that port on oreamnos — the blocky/DoH service only exists on the router
host, which oreamnos does not import. This left a 502 vhost, a
permanently-down Prometheus scrape target, a dead homepage link, and an
unused Nebula firewall opening.

Remove all four:
- web-server.nix: drop the dns reverse-proxy vhost
- o11y/server.nix: drop the blocky Prometheus scrape job
- homepage/index.html: drop the dead Local DNS link
- oreamnos: drop the unused port 3333 Nebula firewall rule