### PR TITLE
home-server: drop unused web TLS sops secrets

### DIFF
--- a/modules/home-server/web-server.nix
+++ b/modules/home-server/web-server.nix
@@ -48,16 +48,6 @@ let
 in
 {
   config = lib.mkIf cfg.enable {
-    sops.secrets."web/fullchain" = {
-      sopsFile = ../../secrets/home-server.yaml;
-      owner = "nginx";
-      mode = "600";
-    };
-    sops.secrets."web/privkey" = {
-      sopsFile = ../../secrets/home-server.yaml;
-      owner = "nginx";
-      mode = "600";
-    };
     sops.secrets."web/files-htpasswd" = {
       sopsFile = ../../secrets/home-server.yaml;
       owner = "nginx";


### PR DESCRIPTION
web/fullchain and web/privkey were declared but never referenced —
nginx terminates TLS via ACME (step-ca), so these only kept an unused
private key decrypted on disk. Only web/files-htpasswd is actually used.